### PR TITLE
Make buffer_mut take &mut self

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,7 @@ impl SmallBitVec {
         }
     }
 
-    fn buffer_mut(&self) -> &mut [Storage] {
+    fn buffer_mut(&mut self) -> &mut [Storage] {
         unsafe { &mut *self.buffer_raw() }
     }
 


### PR DESCRIPTION
This method is private and happens to be used safely, but with it taking `&self` it could be used to create mutable aliasing and possibly UB.