### PR TITLE
Optimize SmallBitVec::remove

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -207,3 +207,23 @@ fn bench_from_elem_sbv(b: &mut Bencher) {
     });
     b.bytes = cap as u64 / 8;
 }
+
+#[bench]
+fn bench_remove_small(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = SmallBitVec::from_elem(U32_BITS as u32, false);
+        for _ in 0..U32_BITS {
+            v.remove(0);
+        }
+    });
+}
+
+#[bench]
+fn bench_remove_big(b: &mut Bencher) {
+    b.iter(|| {
+        let mut v = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+        for _ in 0..200 {
+            v.remove(0);
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -893,7 +893,39 @@ mod tests {
         v.push(true);
 
         v.remove(1);
-        assert_eq!(format!("{:?}", v), "[0, 0, 0, 1]")
+        assert_eq!(format!("{:?}", v), "[0, 0, 0, 1]");
+        v.remove(0);
+        assert_eq!(format!("{:?}", v), "[0, 0, 1]");
+        v.remove(2);
+        assert_eq!(format!("{:?}", v), "[0, 0]");
+        v.remove(1);
+        assert_eq!(format!("{:?}", v), "[0]");
+        v.remove(0);
+        assert_eq!(format!("{:?}", v), "[]");
+    }
+
+    #[test]
+    fn remove_big() {
+        let mut v = SmallBitVec::from_elem(256, false);
+        v.set(100, true);
+        v.set(255, true);
+        v.remove(0);
+        assert_eq!(v.len(), 255);
+        assert_eq!(v.get(0), false);
+        assert_eq!(v.get(99), true);
+        assert_eq!(v.get(100), false);
+        assert_eq!(v.get(253), false);
+        assert_eq!(v.get(254), true);
+
+        v.remove(254);
+        assert_eq!(v.len(), 254);
+        assert_eq!(v.get(0), false);
+        assert_eq!(v.get(99), true);
+        assert_eq!(v.get(100), false);
+        assert_eq!(v.get(253), false);
+
+        v.remove(99);
+        assert_eq!(v, SmallBitVec::from_elem(253, false));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,15 +278,18 @@ impl SmallBitVec {
     ///
     /// Panics if the index is out of bounds.
     pub fn remove(&mut self, idx: u32) {
-        assert!(idx < self.len(), "Index {} out of bounds", idx);
+        let len = self.len();
+        assert!(idx < len, "Index {} out of bounds", idx);
 
-        for i in (idx+1)..self.len() {
+        for i in (idx+1)..len {
             unsafe {
                 let next_val = self.get_unchecked(i);
                 self.set_unchecked(i - 1, next_val);
             }
         }
-        self.pop();
+        unsafe {
+            self.set_len(len - 1);
+        }
     }
 
     /// Remove all elements from the vector, without deallocating its buffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,10 +55,16 @@ fn inline_shift(n: u32) -> u32 {
 fn inline_index(n: u32) -> usize {
     1 << inline_shift(n)
 }
-/// An inline vector with the nth first bits plus the length mark set.
+
+/// An inline vector with the leftmost `n` bits set.
 fn inline_ones(n: u32) -> usize {
-    !0 << inline_shift(n)
+    if n == 0 {
+        0
+    } else {
+        !0 << (inline_bits() - n)
+    }
 }
+
 /// If the rightmost bit of `data` is set, then the remaining bits of `data`
 /// are a pointer to a heap allocation.
 const HEAP_FLAG: usize = 1;
@@ -129,7 +135,7 @@ impl SmallBitVec {
         if len <= inline_capacity() {
             return SmallBitVec {
                 data: if val {
-                    inline_ones(len)
+                    inline_ones(len + 1)
                 } else {
                     inline_index(len)
                 }
@@ -346,7 +352,7 @@ impl SmallBitVec {
         }
 
         if self.is_inline() {
-            let mask = inline_ones(len - 1);
+            let mask = inline_ones(len);
             self.data & mask == 0
         } else {
             for &storage in self.buffer() {
@@ -375,7 +381,7 @@ impl SmallBitVec {
         }
 
         if self.is_inline() {
-            let mask = inline_ones(len - 1);
+            let mask = inline_ones(len);
             self.data & mask == mask
         } else {
             for &storage in self.buffer() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,14 +287,23 @@ impl SmallBitVec {
         let len = self.len();
         assert!(idx < len, "Index {} out of bounds", idx);
 
-        for i in (idx+1)..len {
-            unsafe {
-                let next_val = self.get_unchecked(i);
-                self.set_unchecked(i - 1, next_val);
+        if self.is_inline() {
+            // Shift later bits, including the length bit, toward the front.
+            let mask = !inline_ones(idx);
+            let new_vals = (self.data & mask) << 1;
+            self.data = (self.data & !mask) | (new_vals & mask);
+        } else {
+            // Shift later bits toward the front.
+            for i in (idx+1)..len {
+                unsafe {
+                    let next_val = self.get_unchecked(i);
+                    self.set_unchecked(i - 1, next_val);
+                }
             }
-        }
-        unsafe {
-            self.set_len(len - 1);
+            // Decrement the length.
+            unsafe {
+                self.set_len(len - 1);
+            }
         }
     }
 


### PR DESCRIPTION
This speeds up worst-case `remove` performance by about 30x. Fixes #4.