### PR TITLE
Convert u32 methods to usize

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -22,7 +22,7 @@ use smallbitvec::SmallBitVec;
 use test::{Bencher, black_box};
 
 const BENCH_BITS : usize = 1 << 14;
-const U32_BITS: usize = 32;
+const USIZE_BITS: usize = ::std::mem::size_of::<usize>() * 8;
 
 fn rng() -> XorShiftRng {
     weak_rng()
@@ -34,7 +34,7 @@ fn bench_bit_set_big_fixed_bv(b: &mut Bencher) {
     let mut bit_vec = BitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set((r.next_u32() as usize) % BENCH_BITS, true);
+            bit_vec.set((r.next_u64() as usize) % BENCH_BITS, true);
         }
         black_box(&bit_vec);
     });
@@ -43,10 +43,10 @@ fn bench_bit_set_big_fixed_bv(b: &mut Bencher) {
 #[bench]
 fn bench_bit_set_big_fixed_sbv(b: &mut Bencher) {
     let mut r = rng();
-    let mut bit_vec = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+    let mut bit_vec = SmallBitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set(r.next_u32() % BENCH_BITS as u32, true);
+            bit_vec.set(r.next_u64() as usize % BENCH_BITS, true);
         }
         black_box(&bit_vec);
     });
@@ -58,7 +58,7 @@ fn bench_big_set_big_variable_bv(b: &mut Bencher) {
     let mut bit_vec = BitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set((r.next_u32() as usize) % BENCH_BITS, r.gen());
+            bit_vec.set((r.next_u64() as usize) % BENCH_BITS, r.gen());
         }
         black_box(&bit_vec);
     });
@@ -67,10 +67,10 @@ fn bench_big_set_big_variable_bv(b: &mut Bencher) {
 #[bench]
 fn bench_bit_set_big_variable_sbv(b: &mut Bencher) {
     let mut r = rng();
-    let mut bit_vec = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+    let mut bit_vec = SmallBitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set(r.next_u32() % BENCH_BITS as u32, r.gen());
+            bit_vec.set(r.next_u64() as usize % BENCH_BITS, r.gen());
         }
         black_box(&bit_vec);
     });
@@ -79,10 +79,10 @@ fn bench_bit_set_big_variable_sbv(b: &mut Bencher) {
 #[bench]
 fn bench_bit_set_small_bv(b: &mut Bencher) {
     let mut r = rng();
-    let mut bit_vec = BitVec::from_elem(U32_BITS, false);
+    let mut bit_vec = BitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set((r.next_u32() as usize) % U32_BITS, true);
+            bit_vec.set((r.next_u64() as usize) % USIZE_BITS, true);
         }
         black_box(&bit_vec);
     });
@@ -91,10 +91,10 @@ fn bench_bit_set_small_bv(b: &mut Bencher) {
 #[bench]
 fn bench_bit_set_small_sbv(b: &mut Bencher) {
     let mut r = rng();
-    let mut bit_vec = SmallBitVec::from_elem(U32_BITS as u32, false);
+    let mut bit_vec = SmallBitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         for _ in 0..100 {
-            bit_vec.set(r.next_u32() % U32_BITS as u32, true);
+            bit_vec.set(r.next_u64() as usize % USIZE_BITS, true);
         }
         black_box(&bit_vec);
     });
@@ -102,8 +102,8 @@ fn bench_bit_set_small_sbv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_small_eq_bv(b: &mut Bencher) {
-    let x = BitVec::from_elem(U32_BITS, false);
-    let y = BitVec::from_elem(U32_BITS, false);
+    let x = BitVec::from_elem(USIZE_BITS, false);
+    let y = BitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         x == y
     });
@@ -111,8 +111,8 @@ fn bench_bit_vec_small_eq_bv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_small_eq_sbv(b: &mut Bencher) {
-    let x = SmallBitVec::from_elem(U32_BITS as u32, false);
-    let y = SmallBitVec::from_elem(U32_BITS as u32, false);
+    let x = SmallBitVec::from_elem(USIZE_BITS, false);
+    let y = SmallBitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         x == y
     });
@@ -129,8 +129,8 @@ fn bench_bit_vec_big_eq_bv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_big_eq_sbv(b: &mut Bencher) {
-    let x = SmallBitVec::from_elem(BENCH_BITS as u32, false);
-    let y = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+    let x = SmallBitVec::from_elem(BENCH_BITS, false);
+    let y = SmallBitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         x == y
     });
@@ -138,7 +138,7 @@ fn bench_bit_vec_big_eq_sbv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_small_iter_bv(b: &mut Bencher) {
-    let bit_vec = BitVec::from_elem(U32_BITS, false);
+    let bit_vec = BitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         let mut sum = 0;
         for _ in 0..10 {
@@ -152,7 +152,7 @@ fn bench_bit_vec_small_iter_bv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_small_iter_sbv(b: &mut Bencher) {
-    let bit_vec = SmallBitVec::from_elem(U32_BITS as u32, false);
+    let bit_vec = SmallBitVec::from_elem(USIZE_BITS, false);
     b.iter(|| {
         let mut sum = 0;
         for _ in 0..10 {
@@ -178,7 +178,7 @@ fn bench_bit_vec_big_iter_bv(b: &mut Bencher) {
 
 #[bench]
 fn bench_bit_vec_big_iter_sbv(b: &mut Bencher) {
-    let bit_vec = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+    let bit_vec = SmallBitVec::from_elem(BENCH_BITS, false);
     b.iter(|| {
         let mut sum = 0;
         for pres in &bit_vec {
@@ -200,7 +200,7 @@ fn bench_from_elem_bv(b: &mut Bencher) {
 
 #[bench]
 fn bench_from_elem_sbv(b: &mut Bencher) {
-    let cap = black_box(BENCH_BITS) as u32;
+    let cap = black_box(BENCH_BITS);
     let bit = black_box(true);
     b.iter(|| {
         SmallBitVec::from_elem(cap, bit)
@@ -211,8 +211,8 @@ fn bench_from_elem_sbv(b: &mut Bencher) {
 #[bench]
 fn bench_remove_small(b: &mut Bencher) {
     b.iter(|| {
-        let mut v = SmallBitVec::from_elem(U32_BITS as u32, false);
-        for _ in 0..U32_BITS {
+        let mut v = SmallBitVec::from_elem(USIZE_BITS, false);
+        for _ in 0..USIZE_BITS {
             v.remove(0);
         }
     });
@@ -221,7 +221,7 @@ fn bench_remove_small(b: &mut Bencher) {
 #[bench]
 fn bench_remove_big(b: &mut Bencher) {
     b.iter(|| {
-        let mut v = SmallBitVec::from_elem(BENCH_BITS as u32, false);
+        let mut v = SmallBitVec::from_elem(BENCH_BITS, false);
         for _ in 0..200 {
             v.remove(0);
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -79,20 +79,20 @@ fn push_many() {
 
     for i in 0..500 {
         assert_eq!(v.get(i).unwrap(), (i % 3 == 0), "{}", i);
-        assert_eq!(v[i as usize], v.get(i).unwrap());
+        assert_eq!(v[i], v.get(i).unwrap());
     }
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "index out of range")]
 fn index_out_of_bounds() {
     let v = SmallBitVec::new();
     v[0];
 }
 
 #[test]
-#[should_panic]
-fn index_u32_overflow() {
+#[should_panic(expected = "index out of range")]
+fn index_out_of_bounds_nonempty() {
     let mut v = SmallBitVec::new();
     v.push(true);
     v[1 << 32];


### PR DESCRIPTION
```
master: (47223ba07e2cd34bf3599e909b121e0dd061a957)

running 18 tests
test bench_big_set_big_variable_bv  ... bench:         677 ns/iter (+/- 197)
test bench_bit_set_big_fixed_bv     ... bench:         362 ns/iter (+/- 50)
test bench_bit_set_big_fixed_sbv    ... bench:         501 ns/iter (+/- 113)
test bench_bit_set_big_variable_sbv ... bench:       1,189 ns/iter (+/- 239)
test bench_bit_set_small_bv         ... bench:         362 ns/iter (+/- 64)
test bench_bit_set_small_sbv        ... bench:         495 ns/iter (+/- 142)
test bench_bit_vec_big_eq_bv        ... bench:         362 ns/iter (+/- 98)
test bench_bit_vec_big_eq_sbv       ... bench:         110 ns/iter (+/- 40)
test bench_bit_vec_big_iter_bv      ... bench:      14,272 ns/iter (+/- 4,332)
test bench_bit_vec_big_iter_sbv     ... bench:      34,880 ns/iter (+/- 6,268)
test bench_bit_vec_small_eq_bv      ... bench:           1 ns/iter (+/- 0)
test bench_bit_vec_small_eq_sbv     ... bench:           3 ns/iter (+/- 1)
test bench_bit_vec_small_iter_bv    ... bench:         429 ns/iter (+/- 93)
test bench_bit_vec_small_iter_sbv   ... bench:         706 ns/iter (+/- 109)
test bench_from_elem_bv             ... bench:          93 ns/iter (+/- 14) = 22021 MB/s
test bench_from_elem_sbv            ... bench:          97 ns/iter (+/- 13) = 21113 MB/s
test bench_remove_big               ... bench:     275,131 ns/iter (+/- 42,724)
test bench_remove_small             ... bench:         131 ns/iter (+/- 17)


usize: (084b7f3f31eb5ee7afd5a4293dcd277fa3f58b00)

running 18 tests
test bench_big_set_big_variable_bv  ... bench:         762 ns/iter (+/- 419)
test bench_bit_set_big_fixed_bv     ... bench:         498 ns/iter (+/- 207)
test bench_bit_set_big_fixed_sbv    ... bench:         573 ns/iter (+/- 143)
test bench_bit_set_big_variable_sbv ... bench:       1,297 ns/iter (+/- 517)
test bench_bit_set_small_bv         ... bench:         448 ns/iter (+/- 133)
test bench_bit_set_small_sbv        ... bench:         567 ns/iter (+/- 220)
test bench_bit_vec_big_eq_bv        ... bench:         418 ns/iter (+/- 139)
test bench_bit_vec_big_eq_sbv       ... bench:         106 ns/iter (+/- 25)
test bench_bit_vec_big_iter_bv      ... bench:      14,175 ns/iter (+/- 1,791)
test bench_bit_vec_big_iter_sbv     ... bench:      46,150 ns/iter (+/- 5,398)
test bench_bit_vec_small_eq_bv      ... bench:           2 ns/iter (+/- 0)
test bench_bit_vec_small_eq_sbv     ... bench:          11 ns/iter (+/- 2)
test bench_bit_vec_small_iter_bv    ... bench:         642 ns/iter (+/- 78)
test bench_bit_vec_small_iter_sbv   ... bench:       1,920 ns/iter (+/- 312)
test bench_from_elem_bv             ... bench:          78 ns/iter (+/- 11) = 26256 MB/s
test bench_from_elem_sbv            ... bench:          85 ns/iter (+/- 11) = 24094 MB/s
test bench_remove_big               ... bench:     139,969 ns/iter (+/- 41,473)
test bench_remove_small             ... bench:         431 ns/iter (+/- 59)
```

Upcoming PRs for Travis, `cargo fmt` + `cargo clippy`, and `.range(Range<usize>)` if I get to it.