### PR TITLE
Add Travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+rust:
+  - nightly
+  - beta
+  - stable
+script: |
+  cargo build --verbose &&
+  cargo build --all-features --verbose &&
+  cargo test --verbose &&
+  cargo test --all-features --verbose &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features) &&
+  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)
+notifications:
+  webhooks: http://build.servo.org:54856/travis


### PR DESCRIPTION
Closes #3

Copies [servo/rust-smallvec](https://github.com/servo/rust-smallvec/blob/master/.travis.yml)'s .travis.yml verbatim.

Here is the [passing Travis build](https://travis-ci.org/dbkaplun/smallbitvec/builds/366327409) for this commit on my branch.

When this is merged, an owner of smallbitvec will need to enable Travis for the repository. [Instructions here](https://docs.travis-ci.com/user/getting-started/#To-get-started-with-Travis-CI)

Thanks!
