### PR TITLE
Add into_raw and from_raw functions.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,6 +186,18 @@ fn buffer_len(cap: usize) -> usize {
     (cap + bits_per_storage() - 1) / bits_per_storage()
 }
 
+/// A typed representation of a `SmallBitVec`'s internal storage.
+///
+/// The layout of the data inside both enum variants is a private implementation detail.
+pub enum InternalStorage {
+    /// The internal representation of a `SmallBitVec` that has not spilled to a
+    /// heap allocation.
+    Inline(usize),
+
+    /// The contents of the heap allocation of a spilled `SmallBitVec`.
+    Spilled(Box<[usize]>),
+}
+
 impl SmallBitVec {
     /// Create an empty vector.
     #[inline]
@@ -612,6 +624,66 @@ impl SmallBitVec {
             Some((self.data & !HEAP_FLAG) as *const Storage)
         } else {
             None
+        }
+    }
+
+    /// Converts this `SmallBitVec` into its internal representation.
+    ///
+    /// The layout of the data inside both enum variants is a private implementation detail.
+    #[inline]
+    pub fn into_storage(self) -> InternalStorage {
+        if self.is_heap() {
+            let alloc_len = header_len() + self.header().buffer_len;
+            let ptr = self.header_raw() as *mut Storage;
+            let slice = unsafe { Box::from_raw(slice::from_raw_parts_mut(ptr, alloc_len)) };
+            forget(self);
+            InternalStorage::Spilled(slice)
+        } else {
+            InternalStorage::Inline(self.data)
+        }
+    }
+
+    /// Creates a `SmallBitVec` directly from the internal storage of another
+    /// `SmallBitVec`.
+    ///
+    /// # Safety
+    ///
+    /// This is highly unsafe.  `storage` needs to have been previously generated
+    /// via `SmallBitVec::into_storage` (at least, it's highly likely to be
+    /// incorrect if it wasn't.)  Violating this may cause problems like corrupting the
+    /// allocator's internal data structures.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use smallbitvec::{InternalStorage, SmallBitVec};
+    ///
+    /// fn main() {
+    ///     let v = SmallBitVec::from_elem(200, false);
+    ///
+    ///     // Get the internal representation of the SmallBitVec.
+    ///     // unless we transfer its ownership somewhere else.
+    ///     let storage = v.into_storage();
+    ///
+    ///     /// Make a copy of the SmallBitVec's data.
+    ///     let cloned_storage = match storage {
+    ///         InternalStorage::Spilled(vs) => InternalStorage::Spilled(vs.clone()),
+    ///         inline => inline,
+    ///     };
+    ///
+    ///     /// Create a new SmallBitVec from the coped storage.
+    ///     let v = unsafe { SmallBitVec::from_storage(cloned_storage) };
+    /// }
+    /// ```
+    pub unsafe fn from_storage(storage: InternalStorage) -> SmallBitVec {
+        match storage {
+            InternalStorage::Inline(data) => SmallBitVec { data },
+            InternalStorage::Spilled(vs) => {
+                let ptr = Box::into_raw(vs);
+                SmallBitVec {
+                    data: (ptr as *mut usize as usize) | HEAP_FLAG,
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Similarly to https://github.com/servo/rust-smallvec/pull/130 I have need to grab out the heap storage from a `SmallBitVec` and move it somewhere else, for https://bugzilla.mozilla.org/show_bug.cgi?id=1474793.  Adding functions to convert the `SmallBitVec` into its slice of storage values, without saying anything more about the format of the data in there, seemed the best way to do this.