### PR TITLE
use no_std_compat to turn smallbitvec into a no_std/alloc crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,15 @@ keywords = ["bitvec", "bitmap", "vec", "data-structures"]
 categories = ["data-structures"]
 readme = "README.md"
 
+
+[features]
+default = ['std']
+std = []
+
+[dependencies]
+no-std-compat = {version="0.1.0", features=["alloc", ]}
+
+
 [dev-dependencies]
 rand = "0.4.2"
 bit-vec = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [features]
 default = ['std']
-std = []
+std = ["no-std-compat/std"]
 
 [dependencies]
 no-std-compat = {version="0.1.0", features=["alloc", ]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@
 //! # Example
 //!
 //! ```
+//! use std::prelude::v1::*;
+
 //! use smallbitvec::SmallBitVec;
 //!
 //! let mut v = SmallBitVec::new();
@@ -27,14 +29,21 @@
 //! assert_eq!(v[0], true);
 //! assert_eq!(v[1], false);
 //! ```
+ 
+#![cfg_attr(not(std), no_std)]
+#![no_std]
+
+extern crate no_std_compat as std;
+use std::prelude::v1::*;
 
 use std::cmp::max;
 use std::fmt;
-use std::hash;
 use std::iter::{DoubleEndedIterator, ExactSizeIterator, FromIterator};
 use std::mem::{forget, replace, size_of};
 use std::ops::{Index, Range};
 use std::slice;
+#[cfg(std)]
+use std::hash;
 
 /// Creates a [`SmallBitVec`] containing the arguments.
 ///
@@ -845,6 +854,7 @@ impl Index<usize> for SmallBitVec {
     }
 }
 
+#[cfg(std)]
 impl hash::Hash for SmallBitVec {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
 
 extern crate no_std_compat as std;
 use std::prelude::v1::*;
+use std::vec;
 
 use std::cmp::max;
 use std::fmt;


### PR DESCRIPTION
I'd like to use smallbitvec in an embedded environment - no_std, but I do have an allocator.

This is almost trivial using the no_std_compat crate, though we do need to define a 'std' feature (enabled by default) behind which the I hid the hash implementation.

Unfortunately, this makes the doc tests report ```error: no global memory allocator found but one is required; link to std or add #[global_allocator] to a static item that implements the GlobalAlloc trait.```. It's a cosmetic issue, the tests still all pass though - see https://github.com/rust-lang/rust/issues/54010.

I'm fairly new to rust - please tell me if anything of this is not rustacean.
