### PR TITLE
Allow using smallbitvec in no_std + alloc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - nightly
   - beta
   - stable
+  - 1.36.0
 script: |
   cargo build --verbose &&
   cargo build --all-features --verbose &&

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,5 @@ rust:
   - 1.36.0
 script: |
   cargo build --verbose &&
-  cargo build --all-features --verbose &&
   cargo test --verbose &&
-  cargo test --all-features --verbose &&
-  ([ $TRAVIS_RUST_VERSION != nightly ] || cargo test --verbose --no-default-features) &&
   ([ $TRAVIS_RUST_VERSION != nightly ] || cargo bench --verbose bench)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,19 @@
 //! assert_eq!(v[1], false);
 //! ```
 
-use std::cmp::max;
-use std::fmt;
-use std::hash;
-use std::iter::{DoubleEndedIterator, ExactSizeIterator, FromIterator};
-use std::mem::{forget, replace, size_of};
-use std::ops::{Index, Range};
-use std::slice;
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{vec, vec::Vec, boxed::Box};
+
+use core::cmp::max;
+use core::fmt;
+use core::hash;
+use core::iter::{DoubleEndedIterator, ExactSizeIterator, FromIterator};
+use core::mem::{forget, replace, size_of};
+use core::ops::{Index, Range};
+use core::slice;
 
 /// Creates a [`SmallBitVec`] containing the arguments.
 ///

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -9,6 +9,8 @@
 
 use super::*;
 
+use alloc::format;
+
 #[cfg(target_pointer_width = "32")]
 #[test]
 fn test_inline_capacity() {


### PR DESCRIPTION
Ah, embarrassingly, I wrote this before checking for an existing PR, so this does the same thing as #19. That said, it doesn't require nightly, and doesn't add any dependencies, and includes the CI changes as well.

I don't know what the MSRV is for `smallbitvec`, but I made an attempt not to change anything for people using it in the default configuration.