### PR TITLE
Allow creating empty iterators.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallbitvec"
-version = "2.4.0"
+version = "2.4.1"
 authors = ["Matt Brubeck <mbrubeck@limpet.net>"]
 license = "MIT / Apache-2.0"
 description = "A bit vector optimized for size and inline storage"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -346,6 +346,12 @@ fn truncate_large() {
 }
 
 #[test]
+fn iter_default() {
+    assert!(Iter::default().next().is_none());
+    assert!(Iter::default().next_back().is_none());
+}
+
+#[test]
 fn resize() {
     let mut v = sbvec![false, true, false, false, true];
     v.resize(3, false);


### PR DESCRIPTION
This simplifies a bit of ugly code in Servo.