### PR TITLE
Improve performance of hashing `SmallBitVec`s

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -16,6 +16,8 @@ extern crate rand;
 extern crate smallbitvec;
 extern crate test;
 
+use std::hash::{Hash, Hasher};
+
 use bit_vec::BitVec;
 use rand::{weak_rng, Rng, XorShiftRng};
 use smallbitvec::SmallBitVec;
@@ -214,4 +216,24 @@ fn bench_remove_big(b: &mut Bencher) {
             v.remove(0);
         }
     });
+}
+
+#[bench]
+fn bench_hash_small(b: &mut Bencher) {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let v = SmallBitVec::from_elem(USIZE_BITS, false);
+    b.iter(|| {
+        v.hash(&mut hasher);
+    });
+    black_box(hasher.finish());
+}
+
+#[bench]
+fn bench_hash_big(b: &mut Bencher) {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let v = SmallBitVec::from_elem(BENCH_BITS, false);
+    b.iter(|| {
+        v.hash(&mut hasher);
+    });
+    black_box(hasher.finish());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -870,7 +870,7 @@ impl hash::Hash for SmallBitVec {
         let len = self.len();
         len.hash(state);
         if self.is_inline() {
-            (self.data & inline_ones(len)).reverse_bits().hash(state);
+            reverse_bits(self.data & inline_ones(len)).hash(state);
         } else {
             let full_blocks = len / bits_per_storage();
             let remainder = len % bits_per_storage();
@@ -1048,4 +1048,14 @@ impl<'a> Index<usize> for VecRange<'a> {
         assert!(vec_i < self.range.end, "index out of range");
         &self.vec[vec_i]
     }
+}
+
+fn reverse_bits(mut value: usize) -> usize {
+    let mut result = 0;
+    for _ in 0..inline_bits() {
+        result <<= 1;
+        result |= value & 1;
+        value >>= 1;
+    }
+    result
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -365,3 +365,33 @@ fn resize() {
     assert_eq!(v.get(98).unwrap(), false);
     assert_eq!(v.get(99).unwrap(), false);
 }
+
+#[test]
+fn hash() {
+    extern crate std;
+    use core::hash::{Hash, Hasher};
+
+    let v1 = sbvec![true, false, true, false, true, true, true];
+    let mut v2 = v1.clone();
+    v2.reserve(100_000);
+    assert_eq!(v1, v2);
+
+    let hash = |v: &SmallBitVec| {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        v.hash(&mut hasher);
+        hasher.finish()
+    };
+
+    assert_eq!(hash(&v1), hash(&v2));
+
+    let mut v3 = v1.clone();
+    v3.push(false);
+    assert_ne!(hash(&v1), hash(&v3));
+
+    let mut v4 = v2.clone();
+    v4.push(false);
+    assert_ne!(hash(&v2), hash(&v4));
+
+    assert_eq!(v3, v4);
+    assert_eq!(hash(&v3), hash(&v4));
+}


### PR DESCRIPTION
Hash one word at a time instead of one bit at a time.

Performance measurements:

Before:
```
small                   time:   [362.51 ns 363.83 ns 365.24 ns]
large                   time:   [89.993 us 90.255 us 90.548 us]
```

After:
```
small                   time:   [23.911 ns 23.976 ns 24.047 ns]
                        change: [-93.407% -93.378% -93.346%] (p = 0.00 < 0.05)
large                   time:   [639.93 ns 642.11 ns 644.49 ns]
                        change: [-99.298% -99.293% -99.289%] (p = 0.00 < 0.05)
```