### PR TITLE
Implement MallocSizeOf for smallbitvec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "malloc_size_of"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fd9b382a64a1424df42ce69cd84485336cfeca66795a210ea9bd2fe388a0af"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -69,9 +75,10 @@ dependencies = [
 
 [[package]]
 name = "smallbitvec"
-version = "2.5.3"
+version = "2.5.4"
 dependencies = [
  "bit-vec",
+ "malloc_size_of",
  "rand",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smallbitvec"
-version = "2.5.3"
+version = "2.5.4"
 authors = ["Matt Brubeck <mbrubeck@limpet.net>"]
 license = "MIT OR Apache-2.0"
 description = "A bit vector optimized for size and inline storage"
@@ -11,6 +11,9 @@ categories = ["data-structures"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.56"
+
+[dependencies]
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -865,6 +865,17 @@ impl Index<usize> for SmallBitVec {
     }
 }
 
+#[cfg(feature = "malloc_size_of")]
+impl malloc_size_of::MallocSizeOf for SmallBitVec {
+    fn size_of(&self, ops: &mut malloc_size_of::MallocSizeOfOps) -> usize {
+        if let Some(ptr) = self.heap_ptr() {
+            unsafe { ops.malloc_size_of(ptr) }
+        } else {
+            0
+        }
+    }
+}
+
 impl hash::Hash for SmallBitVec {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies.

This PR adds the implementation of `MallocSizeOf` to the `smallbitvec` crate.