### PR TITLE
Fix index_out_of_bounds_nonempty test on 32-bit platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ const fn inline_bits() -> usize {
 /// - The rightmost bit is set to zero to signal an inline vector.
 /// - The position of the rightmost nonzero bit encodes the length.
 #[inline(always)]
-const fn inline_capacity() -> usize {
+pub(crate) const fn inline_capacity() -> usize {
     inline_bits() - 2
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,7 +103,7 @@ fn index_out_of_bounds() {
 fn index_out_of_bounds_nonempty() {
     let mut v = SmallBitVec::new();
     v.push(true);
-    v[1 << 32];
+    v[1 << inline_capacity()];
 }
 
 #[test]


### PR DESCRIPTION
`1 << 32` fails with an overflow. Use `inline_capacity()` instead so it adjusts by platform.